### PR TITLE
ship-as-trial doc: Update to no longer need --key-file

### DIFF
--- a/ship-as-trial.md
+++ b/ship-as-trial.md
@@ -65,10 +65,10 @@ If you want to test your code's interactions with the framework, you'll need to 
 You can generate signed tokens for localhost, or for 127.0.0.1, or for any origin that you need to help you test. For example:
 
 ```
-tools/origin_trials/generate_token.py --key-file=tools/origin_trials/eftest.key http://localhost:8000 MyFeature
+tools/origin_trials/generate_token.py http://localhost:8000 MyFeature
 ```
 
-The `eftest.key` file is the private key for the test keypair used by Origin Trials unit tests (tokens generated with this key will **not** work in the browser by default; see the [Developer Guide](developer-guide.md) for instructions on creating real tokens). To use a test token with the browser, run Chrome with the command-line flag:
+The file `tools/origin_trials/eftest.key` is used by default as the private key for the test keypair used by Origin Trials unit tests (tokens generated with this key will **not** work in the browser by default; see the [Developer Guide](developer-guide.md) for instructions on creating real tokens). To use a test token with the browser, run Chrome with the command-line flag:
 
 ```
 --origin-trial-public-key=dRCs+TocuKkocNKa0AtZ4awrt9XKH2SQCI6o4FY6BNA=

--- a/ship-as-trial.md
+++ b/ship-as-trial.md
@@ -74,7 +74,7 @@ The file `tools/origin_trials/eftest.key` is used by default as the private key 
 --origin-trial-public-key=dRCs+TocuKkocNKa0AtZ4awrt9XKH2SQCI6o4FY6BNA=
 ```
 
-This is the public key associated with `eftest.key`. If it doesn't work, see [trial_token_unittest.cc](https://cs.chromium.org/chromium/src/content/common/origin_trials/trial_token_unittest.cc).
+This is the public key associated with `eftest.key`. If it doesn't work, see [trial_token_unittest.cc](https://cs.chromium.org/chromium/src/content/common/origin_trials/trial_token_unittest.cc). If you cannot set command-line switches (e.g., on Chrome OS), you can also directly modify [chrome_origin_trial_policy.cc](https://cs.chromium.org/chromium/src/chrome/common/origin_trials/chrome_origin_trial_policy.cc).
 
 ## Roadmap
 All of this may change, as we respond to your feedback about the framework itself. Please let us know how it works, and what's missing!


### PR DESCRIPTION
No longer needed after https://crbug.com/635803 was fixed.
