### PR TITLE
Add expired state

### DIFF
--- a/check-token.html
+++ b/check-token.html
@@ -135,10 +135,16 @@
      expiryElem.textContent = obj.expiry;
      return;
    }
-   expiryElem.textContent = new Date(expiry * 1000).toLocaleString();
+
+   let expiryDate = new Date(expiry * 1000);
+   expiryElem.textContent = expiryDate.toLocaleString();
+   if (expiryDate < new Date()) {
+     validityElem.textContent = "Expired"
+     return;
+   }
 
    validityElem.classList.remove("invalid");
-   validityElem.textContent = "Valid"
+   validityElem.textContent = "Valid";
  }
 
  tokenElem.oninput = validate;


### PR DESCRIPTION
Instead of having "Valid" for an expired OT token, it will now say "Expired".

![screenshot 2016-10-04 at 11 28 42 am](https://cloud.githubusercontent.com/assets/634478/19069108/bd667a74-8a25-11e6-903a-4a9dcfa939bb.png)

FIX: #15
