### PR TITLE
Language tweaks to encourage production experiments

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ Briefly, the web needs new features, and iteration yields the best designs and i
 
 One of the root causes was that experimental features were available too widely, and thus usage grew unchecked as a result. Ideally, it should be easier to expose and iterate on new features, but reliably limit the experimental population. With a test population of developers committed to providing feedback, and limits in user base size and experiment duration, iteration can happen faster, but without the risk of burn-in.
 
+The origin trial feature is still security-reviewed, tested and launched as a production feature, just time and usage limited to allow for evolving the feature with developer feedback, minimizing the risk of it prematurely becoming a defacto standard.
+
 Please see the [explainer](explainer.md) to learn more about the problem, and why origin trials is a good solution.
 
 ## Signing up for an origin trial

--- a/developer-guide.md
+++ b/developer-guide.md
@@ -4,6 +4,8 @@ Origin trials allow developers to try out new features and give feedback on usab
 
 Once your origin has opted into a trial of an experimental feature you can then build demos and prototypes that your friends and beta testing users can try for the duration of the trial without them needing to flip special flags in Chrome.
 
+You can also run limited in-production experiments to evaluate the effictiveness of a feature at-scale. Just be careful to limit the amount of traffic included in the trial as the trial will automatically disable if it is used in more than 0.5% of Chrome page loads. This is part of the protections in place to prevent the feature from becoming a defacto standard before the experimentation and standards work have completed.
+
 ## How do I enable an experimental feature on my origin?
 
 You can opt any page on your origin into the trial of an experimental feature by [requesting a token for your origin](https://developers.chrome.com/origintrials/). After signing up for a trial, we will generate a token for your origin.
@@ -35,6 +37,8 @@ Each feature that is available as an origin trial can alternatively be enabled o
 
 You can get started experimenting with the new feature on `localhost` either by flipping the flag locally or requesting an origin trial token for `localhost`.
 
+You can enable the feature in automation for testing as well using a command-line flag to enable to corresponding flag: ```--enable-blink-features=xxxxx```.
+
 ## What is the thinking behind origin trials?
 An exploration of the motivations and reasoning behind origin trials is provided in [the explainer](explainer.md). The TL;DR is that we strongly value the feedback of real web developers (that means you!) during the process of designing and standardizing new features. We believe origin trials provide a good way of encouraging that feedback, while being extremely careful that the experiments aren’t used by sites in production-critical roles or as if they’re finalized features.
 
@@ -56,6 +60,8 @@ These are only experiments and there is a good chance that some of them will nev
 
 Origin trials have a built-in safeguard that automatically disables an experimental feature globally if its usage exceeds 0.5% of all Chrome page loads. This is to keep usage limited to developers experimenting and below Chrome’s threshold whereby features used on less than 0.5% of all page loads (as measured by [Chrome Status](https://www.chromestatus.com/metrics/feature/popularity)) may be deprecated.
 
+For very popular sites it is important to experiment with origin trials on a small portion of your traffic until the final feature ships.
+
 ### 4. Isn’t this just vendor prefixing all over again?
 
 This topic has been explored in depth in Alex Russell’s Medium post [Doing Science on the Web](https://medium.com/@slightlylate/doing-science-on-the-web-af26d9be2faa#.94pf1lwmp). A couple of key differences include:
@@ -69,7 +75,7 @@ No, these experimental features have all been held to the same high privacy and 
 
 ### 6. Is there any restriction on which websites can sign up to use experimental features?
 
-Origin trials are available to any website served over HTTPS. Note that there is no policy against specific large sites opting into origin trials, but the system is designed to prevent large populations of the web depending on experimental features. To achieve that, origin trials have a built-in safeguard that automatically limits it globally if its usage exceeds 0.5% of all Chrome page loads. This means that experimental features aren’t suitable for use on large production sites such as the Google home page.
+Origin trials are available to any website served over HTTPS. Note that there is no policy against specific large sites opting into origin trials, but the system is designed to prevent large populations of the web depending on experimental features. To achieve that, origin trials have a built-in safeguard that automatically limits it globally if its usage exceeds 0.5% of all Chrome page loads. This means that experimental features aren’t suitable for full production use on large production sites such as the Google home page though experiments that limit the feature usage on such large sites is encouraged.
 
 ### 7. Is there any review process for signing up a website to access an experimental feature?
 

--- a/developer-guide.md
+++ b/developer-guide.md
@@ -4,7 +4,7 @@ Origin trials allow developers to try out new features and give feedback on usab
 
 Once your origin has opted into a trial of an experimental feature you can then build demos and prototypes that your friends and beta testing users can try for the duration of the trial without them needing to flip special flags in Chrome.
 
-You can also run limited in-production experiments to evaluate the effictiveness of a feature at-scale. Just be careful to limit the amount of traffic included in the trial as the trial will automatically disable if it is used in more than 0.5% of Chrome page loads. This is part of the protections in place to prevent the feature from becoming a defacto standard before the experimentation and standards work have completed.
+You can also run limited production experiments to evaluate the effectiveness of a feature at scale. You must be careful to limit the amount of traffic using the feature, as the trial will automatically disable if is used in more than 0.5% of Chrome page loads (across all sites). This is part of the protections in place to prevent the feature from becoming a defacto standard before the experimentation and standards work have completed.
 
 ## How do I enable an experimental feature on my origin?
 
@@ -37,7 +37,7 @@ Each feature that is available as an origin trial can alternatively be enabled o
 
 You can get started experimenting with the new feature on `localhost` either by flipping the flag locally or requesting an origin trial token for `localhost`.
 
-You can enable the feature in automation for testing as well using a command-line flag to enable to corresponding flag: ```--enable-blink-features=xxxxx```.
+For automated tests, you can enable the feature flag using a Chrome command-line parameter: ```--enable-blink-features=xxxxx```.
 
 ## What is the thinking behind origin trials?
 An exploration of the motivations and reasoning behind origin trials is provided in [the explainer](explainer.md). The TL;DR is that we strongly value the feedback of real web developers (that means you!) during the process of designing and standardizing new features. We believe origin trials provide a good way of encouraging that feedback, while being extremely careful that the experiments aren’t used by sites in production-critical roles or as if they’re finalized features.
@@ -58,9 +58,9 @@ These are only experiments and there is a good chance that some of them will nev
 
 ### 3. What happens if a large site such as a Google service starts depending on an experimental feature?
 
-Origin trials have a built-in safeguard that automatically disables an experimental feature globally if its usage exceeds 0.5% of all Chrome page loads. This is to keep usage limited to developers experimenting and below Chrome’s threshold whereby features used on less than 0.5% of all page loads (as measured by [Chrome Status](https://www.chromestatus.com/metrics/feature/popularity)) may be deprecated.
+Origin trials have a built-in safeguard that automatically disables an experimental feature globally if its total usage exceeds 0.5% of all Chrome page loads. This is to keep usage limited to developers experimenting and below Chrome’s threshold whereby features used on less than 0.5% of all page loads (as measured by [Chrome Status](https://www.chromestatus.com/metrics/feature/popularity)) may be deprecated.
 
-For very popular sites it is important to experiment with origin trials on a small portion of your traffic until the final feature ships.
+For very popular sites it is important to only experiment with a small portion of your traffic when participating in a trial.
 
 ### 4. Isn’t this just vendor prefixing all over again?
 
@@ -75,7 +75,7 @@ No, these experimental features have all been held to the same high privacy and 
 
 ### 6. Is there any restriction on which websites can sign up to use experimental features?
 
-Origin trials are available to any website served over HTTPS. Note that there is no policy against specific large sites opting into origin trials, but the system is designed to prevent large populations of the web depending on experimental features. To achieve that, origin trials have a built-in safeguard that automatically limits it globally if its usage exceeds 0.5% of all Chrome page loads. This means that experimental features aren’t suitable for full production use on large production sites such as the Google home page though experiments that limit the feature usage on such large sites is encouraged.
+Origin trials are available to any website served over HTTPS. Note that there is no policy against specific large sites opting into origin trials, but the system is designed to prevent large populations of the web depending on experimental features. To achieve that, origin trials have a built-in safeguard that automatically limits it globally if its usage exceeds 0.5% of all Chrome page loads. This means that experimental features aren’t suitable for full production use on large production sites such as the Google home page, though experiments with limited usage on large sites is encouraged.
 
 ### 7. Is there any review process for signing up a website to access an experimental feature?
 

--- a/explainer.md
+++ b/explainer.md
@@ -34,7 +34,7 @@ This experience makes it clear that **any system to enable experimentation shoul
 
 Conversely, for unsuccessful features we should ensure that any system to enable experimentation prevents designs we later regret from being baked into the web.
 
-The risks don’t stop there though. Assuming we did ship a feature experimentally, how can we prevent one large company from adopting it and relying on it at-scale, making deprecation or changes to the feature much more difficult? How can we ensure experimental features maintain our high privacy and security standards?
+The risks don’t stop there though. Assuming we did ship a feature experimentally, how can we prevent one large company from adopting it and relying on it at scale, making deprecation or changes to the feature much more difficult? How can we ensure experimental features maintain our high privacy and security standards?
 
 ## A sketch of a solution
 When reflecting on the problem we outlined earlier, it’s clear that we can’t change the fact that web browser engineers are fundamentally different people to web developers. For that reason, we focused our design efforts on coming up with a safe way to encourage web developers to try new features and provide us feedback while maintaining our ability to modify designs, ensure successful experiments result in eventual interoperability and ensure unsuccessful experiments are not baked into production websites.
@@ -50,7 +50,7 @@ This design is expanded in detail later, but first consider how this satisfies t
 - **Ensuring unsuccessful experiments are not baked into production websites:** These experimental APIs will all stop working within a few months and developers will be very aware of this when they sign up.
 
 And when considering those additional risks we were worried about:
-- **Preventing premature at-scale use from forcing us to keep an experimental feature available:** The automatic usage limiting minimizes the ability for major properties to rely on a feature before it is fully developed, and the time-limited design means that inaction results in the feature reverting.
+- **Preventing premature production use from forcing us to keep an experimental feature available:** The automatic usage limiting minimizes the ability for major properties to rely on a feature before it is shipped, and the time-limited design means that inaction results in the feature reverting.
 - **Maintaining our high privacy and security standards:** Features launched as origin trials are only experimental in terms of their syntax and semantics. Otherwise these are features going out to actual end users, and as such will go through Chrome’s standard launch process the same as any other feature to ensure a high bar for privacy and security is maintained.
 
 This design also has the additional benefit that developers cannot simply copy paste code using experimental APIs from Stack Overflow as was possible with prefixes.

--- a/explainer.md
+++ b/explainer.md
@@ -34,7 +34,7 @@ This experience makes it clear that **any system to enable experimentation shoul
 
 Conversely, for unsuccessful features we should ensure that any system to enable experimentation prevents designs we later regret from being baked into the web.
 
-The risks don’t stop there though. Assuming we did ship a feature experimentally, how can we prevent one large company from adopting it and then force us into a game of high stakes deprecation chicken? How can we ensure experimental features maintain our high privacy and security standards?
+The risks don’t stop there though. Assuming we did ship a feature experimentally, how can we prevent one large company from adopting it and relying on it at-scale, making deprecation or changes to the feature much more difficult? How can we ensure experimental features maintain our high privacy and security standards?
 
 ## A sketch of a solution
 When reflecting on the problem we outlined earlier, it’s clear that we can’t change the fact that web browser engineers are fundamentally different people to web developers. For that reason, we focused our design efforts on coming up with a safe way to encourage web developers to try new features and provide us feedback while maintaining our ability to modify designs, ensure successful experiments result in eventual interoperability and ensure unsuccessful experiments are not baked into production websites.
@@ -44,13 +44,13 @@ We believe these constraints are solvable with ‘origin trials’. **In summary
 - Usage of these experiments is constrained to remain below Chrome’s deprecation threshold (< 0.5% of all Chrome page loads) by a system which automatically disables the experiment on all origins if this threshold is exceeded.
 
 This design is expanded in detail later, but first consider how this satisfies the constraints we outlined earlier:
-- **Encouraging developers to try features and provide feedback:** This system allows us to effectively communicate with these developers for the first time, and we believe the ability to use new features to build demos and prototypes that can be shared with friends, Twitter and beta testers will compel developers to try out these features.
-- **Maintaining our ability to change our implementation:** The time-limited nature of an origin trial means that these features will self destruct after a few months whatever happens. This gives us clear cover for making breaking changes. Additionally, no large site can use these features in production thanks to the usage constraint, so we cannot be pressured into extending origin trials by powerful parties.
+- **Encouraging developers to try features and provide feedback:** This system allows us to effectively communicate with these developers for the first time, and we believe the ability to use new features to build demos and prototypes that can be shared with friends, Twitter and beta testers will compel developers to try out these features. Production sites could run limited experiments to gauge the impact of a feature and provide that data as part of the feedback to the feature teams.
+- **Maintaining our ability to change our implementation:** The time-limited nature of an origin trial means that these features will self destruct after a few months whatever happens. This gives us clear cover for making breaking changes. Additionally, no large site can rely on these features for their full production traffic thanks to the usage constraint, so there is minimal risk in causing it to become a defacto-standard prematurely.
 - **Ensuring successful experiments result in eventual interoperability:** Developers will be very aware that the trial they signed up for will end soon, and that their site must therefore rely on proper feature detection (and degrade gracefully without the feature). Assuming the feature is a success we can then communicate any breaking changes to these developers, who can then make the changes and have the feature work with the finalized syntax.
 - **Ensuring unsuccessful experiments are not baked into production websites:** These experimental APIs will all stop working within a few months and developers will be very aware of this when they sign up.
 
 And when considering those additional risks we were worried about:
-- **Preventing one large company from forcing us to keep an experimental feature available:** The automatic usage limiting minimizes the ability for major properties to attempt to force our hand, and the time-limited design means that inaction results in the desirable outcome.
+- **Preventing premature at-scale use from forcing us to keep an experimental feature available:** The automatic usage limiting minimizes the ability for major properties to rely on a feature before it is fully developed, and the time-limited design means that inaction results in the feature reverting.
 - **Maintaining our high privacy and security standards:** Features launched as origin trials are only experimental in terms of their syntax and semantics. Otherwise these are features going out to actual end users, and as such will go through Chrome’s standard launch process the same as any other feature to ensure a high bar for privacy and security is maintained.
 
 This design also has the additional benefit that developers cannot simply copy paste code using experimental APIs from Stack Overflow as was possible with prefixes.
@@ -136,7 +136,7 @@ Beyond surveys, we hope that developers will participate in the community around
   - No, these experimental APIs will all be approved as safe by Chrome’s privacy and security teams.
 
 *Is there any restriction on which websites can sign up to use experimental APIs?*
-  - No, any website can sign up to use an experimental API. The only thing to note is that an experiment will be automatically shut off for all domains if it becomes used on more than 0.5% of all Chrome page loads, which means, unsurprisingly, experimental APIs aren’t suitable for use on very large production sites such as the Google home page.
+  - No, any website can sign up to use an experimental API. The only thing to note is that an experiment will be automatically shut off for all domains if it becomes used on more than 0.5% of all Chrome page loads, which means, unsurprisingly, experimental APIs aren’t suitable for full-production use on very large production sites such as the Google home page. Limited experimental use on very large production sites is encouraged, just not a full launch until the feature itself is no longer experimental.
 
 *Is there any review process for signing up a website to access an experimental API?*
   - No. We do not review domain content before generating a token.


### PR DESCRIPTION
Tweaked some of the language about usage by very large sites to make it clear that experimentation on those sites is still possible (and encouraged), it's just that full production launches are defended against.

Also bubbled up the production-quality details to the main readme.